### PR TITLE
Add support for Pushbullet notifications

### DIFF
--- a/background.js
+++ b/background.js
@@ -28,7 +28,6 @@ function onWatchdog() {
         }
 
         if (subscriptions.length > 0) {
-
           var tests = subscriptions.join('+');
           var xhr = new XMLHttpRequest();
           var time = new Date().getTime();
@@ -37,7 +36,6 @@ function onWatchdog() {
             if (xhr.readyState === 4 && typeof xhr.responseText !== "undefined") {
               try {
                 var resp = JSON.parse(xhr.responseText);
-
                 if (resp.tests && resp.tests.length) {
                   for (var i = 0; i < resp.tests.length; i++) {
                     if (resp.tests[i]['test']) {
@@ -87,16 +85,20 @@ function onWatchdog() {
 }
 
 function doNotifications(test) {
-
+  // Get all the configuration out of storage.
   chrome.storage.sync.get(null, function(items){
     var url = '';
+
+    // If the preference is to link to the issue, and we CAN link to the issue.
     if (items.link_to == 'dorg' && typeof test.dorg_link !== "undefined" && test.dorg_link.length > 0) {
       url = test.dorg_link;
     }
+    // Fall back to linking to the test.
     else {
       url = 'https://qa.drupal.org/pifr/test/' + test.id;
     }
 
+    // Show the notifications that the user has chosen.
     if (items.enable_desktop_notifications) {
       showResultNotification(test, url);
     }

--- a/manifest.json
+++ b/manifest.json
@@ -26,6 +26,15 @@
     "alarms",
     "notifications",
     "storage",
-    "https://qa.drupal.org/"
-  ]
+    "https://qa.drupal.org/",
+    "https://api.pushbullet.com/"
+  ],
+
+  "options_ui": {
+    // Required.
+    "page": "options.html",
+    // Recommended.
+    "chrome_style": true
+  }
+
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>My Test Extension Options</title>
+  <style>
+    body: { padding: 10px; }
+    .description: { font-style: italic; font-size: 9px;}
+  </style>
+</head>
+
+<body>
+  Pushbullet Access Token:<br/>
+  <input type="text" name="pbat" id="pbat" />
+  <div class="description">Found on your "Account Settings" page in Pushbullet.</div>
+
+  <div id="status"></div>
+  <button id="save">Save</button>
+
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.html
+++ b/options.html
@@ -4,17 +4,50 @@
   <title>My Test Extension Options</title>
   <style>
     body: { padding: 10px; }
-    .description: { font-style: italic; font-size: 9px;}
+
+    .form-element { margin-bottom: 1em; }
+    .form-label { font-weight: bold; margin-bottom: .25em;}
+    .description { font-style: italic; font-size: 12px; margin-top: .5em; }
+
+    #status { font-weight: bold; min-height: 1.5em; padding-top: .5em; }
   </style>
 </head>
 
 <body>
-  Pushbullet Access Token:<br/>
-  <input type="text" name="pbat" id="pbat" />
-  <div class="description">Found on your "Account Settings" page in Pushbullet.</div>
+  <div class="form-element">
+    <div class="form-label">Link to:</div>
+    <input type="radio" id="link_to_dorg" name="link_to" value="dorg" />&nbsp;Drupal.org issue if possible<br/>
+    <input type="radio" id="link_to_pifr" name="link_to" value="pifr" />&nbsp;Always the QA/PIFR results page
+    <div class="description">Where do you prefer the notifications link? The
+      drupal.org issue link is not always available, (for example tests against
+      the entire core that are not against a particular issue) so we may fallback to the
+      pifr link sometimes.</div>
+  </div>
+
+  <div class="form-element">
+    <div class="form-label">Enable desktop notificiations?</div>
+    <input type="checkbox" value="1" name="enable_desktop_notifications" id="enable_desktop_notifications" />
+    <label for="enable_desktop_notifications" class="description">Show a native Chrome notification</label>
+  </div>
+
+  <hr />
+
+  <div class="form-element">
+    <div class="form-label">Pushbullet Access Token:</div>
+    <input type="text" name="pbat" id="pbat" />
+    <div class="description">Found on your "Account Settings" page in Pushbullet. Leave blank to disable Pushbullet functionality.
+      Close and re-open the options page after you first enter it if you would like to select a specific device to receive notifications.</div>
+  </div>
+
+  <div class="form-element">
+    <div class="form-label">Device to Notify:</div>
+    <div id="devices"><em>n/a</em></div>
+    <div class="description">You can choose to send to all your Pushbullet devices, or just one. (Sorry, Pushbullet API doesn't support multi-select.)</div>
+  </div>
+
+  <button id="save">Save</button>
 
   <div id="status"></div>
-  <button id="save">Save</button>
 
   <script src="options.js"></script>
 </body>

--- a/options.html
+++ b/options.html
@@ -6,7 +6,7 @@
     body: { padding: 10px; }
 
     .form-element { margin-bottom: 1em; }
-    .form-label { font-weight: bold; margin-bottom: .25em;}
+    .form-label { font-weight: bold; margin-bottom: .25em; }
     .description { font-style: italic; font-size: 12px; margin-top: .5em; }
 
     #status { font-weight: bold; min-height: 1.5em; padding-top: .5em; }

--- a/options.js
+++ b/options.js
@@ -27,8 +27,7 @@ function save_options() {
   });
 }
 
-// Restores select box and checkbox state using the preferences
-// stored in chrome.storage.
+// Restores preference values to the state stored in chrome.storage.
 function restore_options() {
   chrome.storage.sync.get({
     enable_desktop_notifications: '',
@@ -49,17 +48,18 @@ function restore_options() {
 
     if (items.pbat) {
       // If we have an access token, go out and get their list of devices,
-      // so they can choose which devices they would like to have notified.
+      // so they can choose which device they would like to have notified.
       var xhrPB = new XMLHttpRequest();
       xhrPB.open("GET", "https://api.pushbullet.com/v2/devices", false);
       xhrPB.setRequestHeader("Authorization", "Bearer " + items.pbat);
       xhrPB.send(null);
-
       if (xhrPB.status === 200) {
         var options = '<option value="">- All Devices -</option>';
         var resp = JSON.parse(xhrPB.responseText);
         var i = 0;
 
+        // The response is a list of all their devices. As long as the device
+        // is active and pushable, we will display it here.
         for (device of resp.devices) {
           i = i + 1;
           if (device.active && device.pushable) {

--- a/options.js
+++ b/options.js
@@ -1,28 +1,84 @@
 // Saves options to chrome.storage.sync.
 function save_options() {
+  var enable_desktop_notifications = document.getElementById('enable_desktop_notifications').checked;
   var pbat = document.getElementById('pbat').value;
+  var chosen_device = document.getElementById('chosen_device').value;
+
+  var link_to = '';
+  var radios = document.getElementsByName('link_to');
+  for (var j=0, p=radios.length;j<p;j++) {
+    if (radios[j].checked) {
+      link_to = radios[j].value;
+    }
+  }
+
   chrome.storage.sync.set({
-    pbat: pbat
+    enable_desktop_notifications: enable_desktop_notifications,
+    pbat: pbat,
+    chosen_device: chosen_device,
+    link_to: link_to
   }, function() {
     // Update status to let user know options were saved.
     var status = document.getElementById('status');
     status.textContent = 'Options saved.';
     setTimeout(function() {
       status.textContent = '';
-    }, 750);
+    }, 1500);
   });
 }
 
 // Restores select box and checkbox state using the preferences
 // stored in chrome.storage.
 function restore_options() {
-  // Use default value color = 'red' and likesColor = true.
   chrome.storage.sync.get({
+    enable_desktop_notifications: '',
     pbat: '',
+    chosen_device: '',
+    link_to: '',
   }, function(items) {
+    // Bring in existing settings for desktop notifications, the Pushbullet
+    // access token, and where they prefer the notifications to link to.
+    document.getElementById('enable_desktop_notifications').checked = items.enable_desktop_notifications;
     document.getElementById('pbat').value = items.pbat;
+    if (items.link_to == 'dorg') {
+      document.getElementById('link_to_dorg').checked = true;
+    }
+    else {
+      document.getElementById('link_to_pifr').checked = true;
+    }
+
+    if (items.pbat) {
+      // If we have an access token, go out and get their list of devices,
+      // so they can choose which devices they would like to have notified.
+      var xhrPB = new XMLHttpRequest();
+      xhrPB.open("GET", "https://api.pushbullet.com/v2/devices", false);
+      xhrPB.setRequestHeader("Authorization", "Bearer " + items.pbat);
+      xhrPB.send(null);
+
+      if (xhrPB.status === 200) {
+        var options = '<option value="">- All Devices -</option>';
+        var resp = JSON.parse(xhrPB.responseText);
+        var i = 0;
+
+        for (device of resp.devices) {
+          i = i + 1;
+          if (device.active && device.pushable) {
+            var selected = '';
+            if (device.iden == items.chosen_device) selected = ' selected="selected"';
+            options = options + '<option value="' + device.iden + '"' + selected + '>&nbsp;' + device.nickname + '<br/>';
+          }
+        }
+
+        document.getElementById('devices').innerHTML = '<select id="chosen_device" name="chosen_device">' + options + '</select>';
+      }
+      else {
+        document.getElementById('devices').innerHTML = '<p>There was an error retrieving your list of devices.</p>';
+      }
+    }
   });
 }
+
+// When the content is loaded, fire restore_options to set default values.
 document.addEventListener('DOMContentLoaded', restore_options);
-document.getElementById('save').addEventListener('click',
-    save_options);
+// Bind the save_options function to the save button click.
+document.getElementById('save').addEventListener('click', save_options);

--- a/options.js
+++ b/options.js
@@ -1,0 +1,28 @@
+// Saves options to chrome.storage.sync.
+function save_options() {
+  var pbat = document.getElementById('pbat').value;
+  chrome.storage.sync.set({
+    pbat: pbat
+  }, function() {
+    // Update status to let user know options were saved.
+    var status = document.getElementById('status');
+    status.textContent = 'Options saved.';
+    setTimeout(function() {
+      status.textContent = '';
+    }, 750);
+  });
+}
+
+// Restores select box and checkbox state using the preferences
+// stored in chrome.storage.
+function restore_options() {
+  // Use default value color = 'red' and likesColor = true.
+  chrome.storage.sync.get({
+    pbat: '',
+  }, function(items) {
+    document.getElementById('pbat').value = items.pbat;
+  });
+}
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('save').addEventListener('click',
+    save_options);


### PR DESCRIPTION
This pull request adds support for Pushbullet notifications, so notifications can be sent to mobile devices (or anywhere else the user has Pushbullet installed).

It also adds a preference for where the notification should link to, as some people prefer linking to the issue, and others want to go directly to the PIFR page (as it can take some time for the issue page's status to be updated).

This was the result of a discussion with folks during NH Dev Days 2 this past weekend, Sprinting on Twig criticals through D8 Accelerate! Some folks were mentioning that it would be nice to get notifications on their mobile.
